### PR TITLE
[TASK] Remove class_alias statements

### DIFF
--- a/Classes/Address.php
+++ b/Classes/Address.php
@@ -5,9 +5,6 @@ namespace KDambekalns\Faker;
  * This script belongs to the Flow package "Faker".                       *
  *                                                                        */
 
-// define aliae for the legacy vendor namespace
-class_alias('KDambekalns\\Faker\\Address', 'TYPO3\\Faker\\Address');
-
 /**
  * Address class for the Faker package
  *

--- a/Classes/Company.php
+++ b/Classes/Company.php
@@ -5,9 +5,6 @@ namespace KDambekalns\Faker;
  * This script belongs to the Flow package "Faker".                       *
  *                                                                        */
 
-// define aliae for the legacy vendor namespace
-class_alias('KDambekalns\\Faker\\Company', 'TYPO3\\Faker\\Company');
-
 /**
  * Company class for the Faker package
  *

--- a/Classes/Date.php
+++ b/Classes/Date.php
@@ -5,9 +5,6 @@ namespace KDambekalns\Faker;
  * This script belongs to the Flow package "Faker".                       *
  *                                                                        */
 
-// define aliae for the legacy vendor namespace
-class_alias('KDambekalns\\Faker\\Date', 'TYPO3\\Faker\\Date');
-
 /**
  * Date class for the Faker package
  *

--- a/Classes/Faker.php
+++ b/Classes/Faker.php
@@ -5,9 +5,6 @@ namespace KDambekalns\Faker;
  * This script belongs to the Flow package "Faker".                       *
  *                                                                        */
 
-// define aliae for the legacy vendor namespace
-class_alias('KDambekalns\\Faker\\Faker', 'TYPO3\\Faker\\Faker');
-
 /**
  * Faker class for the Faker package
  *

--- a/Classes/Internet.php
+++ b/Classes/Internet.php
@@ -5,9 +5,6 @@ namespace KDambekalns\Faker;
  * This script belongs to the Flow package "Faker".                       *
  *                                                                        */
 
-// define aliae for the legacy vendor namespace
-class_alias('KDambekalns\\Faker\\Internet', 'TYPO3\\Faker\\Internet');
-
 /**
  * Internet class for the Faker package
  *

--- a/Classes/Lorem.php
+++ b/Classes/Lorem.php
@@ -5,9 +5,6 @@ namespace KDambekalns\Faker;
  * This script belongs to the Flow package "Faker".                       *
  *                                                                        */
 
-// define aliae for the legacy vendor namespace
-class_alias('KDambekalns\\Faker\\Lorem', 'TYPO3\\Faker\\Lorem');
-
 /**
  * Lorem class for the Faker package
  *

--- a/Classes/Name.php
+++ b/Classes/Name.php
@@ -5,9 +5,6 @@ namespace KDambekalns\Faker;
  * This script belongs to the Flow package "Faker".                       *
  *                                                                        */
 
-// define aliae for the legacy vendor namespace
-class_alias('KDambekalns\\Faker\\Name', 'TYPO3\\Faker\\Name');
-
 /**
  * Name class for the Faker package
  *

--- a/Classes/Phone.php
+++ b/Classes/Phone.php
@@ -5,9 +5,6 @@ namespace KDambekalns\Faker;
  * This script belongs to the Flow package "Faker".                       *
  *                                                                        */
 
-// define aliae for the legacy vendor namespace
-class_alias('KDambekalns\\Faker\\Phone', 'TYPO3\\Faker\\Phone');
-
 /**
  * Phone class for the Faker package
  *


### PR DESCRIPTION
This change removes the class_alias statements which were added
for backwards compatibility reasons. They do break Flow class autoloading
though.
